### PR TITLE
Implement Plugins DSL.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,16 +6,15 @@ buildscript {
     repositories {
         mavenCentral()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+        maven { url "https://oss.sonatype.org/content/repositories/releases/" }
         maven { url "https://plugins.gradle.org/m2/" }
         jcenter()
     }
+    
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "net.onedaybeard.artemis:artemis-odb-gradle-plugin:2.2.0"
         classpath "net.onedaybeard.artemis:artemis-fluid-gradle-plugin:2.2.0"
-        classpath "de.undercouch:gradle-download-task:3.4.3"
-        classpath "gradle.plugin.com.github.breadmoirai:github-release:2.2.9"
-        classpath "org.beryx:badass-jlink-plugin:2.11.2"
     }
 }
 
@@ -41,12 +40,13 @@ allprojects {
         mavenCentral()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
         maven { url "https://oss.sonatype.org/content/repositories/releases/" }
+        maven { url "https://plugins.gradle.org/m2/" }
+        jcenter()
     }
 }
 
 subprojects {
-    apply plugin: "java"
-
+    
     sourceCompatibility = JavaVersion.VERSION_12
     targetCompatibility = JavaVersion.VERSION_12
 	

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
         jcenter()
     }
-    
+
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "net.onedaybeard.artemis:artemis-odb-gradle-plugin:2.2.0"
@@ -46,13 +46,14 @@ allprojects {
 }
 
 subprojects {
-    
+    apply plugin: "java"
+
     sourceCompatibility = JavaVersion.VERSION_12
     targetCompatibility = JavaVersion.VERSION_12
 	
 	tasks.withType(JavaCompile) {
 		options.encoding = "UTF-8"
-		options.compilerArgs << '-Xlint:unchecked'
+		//options.compilerArgs << '-Xlint:unchecked'
 		//options.deprecation = true
 	}
 }

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: "java"
-
 sourceSets.main.java.srcDirs = ["src/"]
 
 dependencies {

--- a/design/build.gradle
+++ b/design/build.gradle
@@ -1,16 +1,19 @@
-apply plugin: 'application'
+plugins {
+    id 'application'
+    id 'kotlin'
+}
 
-sourceSets.main.java.srcDirs = ["src/"]
-sourceSets.main.resources.srcDirs = ["resources/"]
+sourceSets {
+    main.java.srcDirs = ["src/"]
+    main.resources.srcDirs = ["resources/"]
+}
 
 mainClassName = "launcher.DesignCenterLauncher"
-
-apply plugin: "kotlin"
 
 dependencies {
     compile project(":desktop")
     compile "com.soywiz:kaifu2x:0.4.0"
-    compile "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.2.1"
+    compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.1"
 }
 
 run.dependsOn classes

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -1,17 +1,17 @@
 import groovy.json.JsonSlurper
 
-apply plugin: 'java'
-apply plugin: 'application'
-apply plugin: 'de.undercouch.download'
-apply plugin: 'com.github.breadmoirai.github-release'
-apply plugin: 'org.beryx.jlink'
+plugins {
+    id 'application'
+    id "de.undercouch.download" version "4.0.0"
+    id "com.github.breadmoirai.github-release" version "2.2.9"
+}
 
 sourceSets {
     main.java.srcDirs = ["src/"]
     main.resources.srcDirs = ["assets/"]
 }
 
-def osName() { System.getProperty('os.name').toLowerCase(Locale.ROOT) }
+static def osName() { System.getProperty('os.name').toLowerCase(Locale.ROOT) }
 
 if (osName().contains('mac')) {
     run {
@@ -148,13 +148,4 @@ githubRelease {
     prerelease true
     releaseAssets project.file('build/zip/').listFiles()
     apiEndpoint "https://api.github.com"
-}
-
-jlink {
-
-    jpackage {
-        jpackageHome = "${projectDir}/packing/jdks/jpack/bin"
-        outputDir = releasesDir()
-        skipInstaller = true
-    }
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'application'
+plugins {
+    id 'application'
+}
 
 sourceSets {
     main.java.srcDirs = ["src/"]

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -1,7 +1,7 @@
-apply plugin: "artemis-fluid"
-apply plugin: "artemis"
-
-[compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
+plugins {
+    id 'artemis-fluid'
+    id 'artemis'
+}
 
 dependencies {
     compile project(":components")


### PR DESCRIPTION
NOTE: i also removed the jlink plugin that isn't working.

> This way of adding plugins to a project is much more than a more convenient syntax. The plugins DSL is processed in a way which allows Gradle to determine the plugins in use very early and very quickly. This allows Gradle to do smart things such as:
> 
> - Optimize the loading and reuse of plugin classes.
> 
> - Allow different plugins to use different versions of dependencies.
> 
> - Provide editors detailed information about the potential properties and values in the buildscript for editing assistance.
> 
> This requires that plugins be specified in a way that Gradle can easily and quickly extract, before executing the rest of the build script. It also requires that the definition of plugins to use be somewhat static.
> 
> There are some key differences between the plugins {} block mechanism and the “traditional” apply() method mechanism. There are also some constraints, some of which are temporary limitations while the mechanism is still being developed and some are inherent to the new approach.

For more info. about this feature, https://docs.gradle.org/current/userguide/plugins.html#plugins_dsl_limitations