### PR TITLE
Implementación de Jpackage parte 2 - Refactorización de parametros y cuestiones necesarias para hacer uso de él

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ out/
 **/out/
 desktop/*.tar.gz
 desktop/*.zip
-desktop/jdk*
+desktop/jdk-14
+desktop/jre
+desktop/openjdk-14-jpackage*.zip
 desktop/desktop*
 desktop/Screenshots*

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -29,6 +29,7 @@ def inputPath = "${projectDir}/build/input/"
 def jpackagePath = osName().contains('mac') ? "${jdkFolder}/jdk-14.jdk/Contents/Home/bin/jpackage" : "${jdkFolder}/jdk-14/bin/jpackage"
 def jdkPath = osName().contains('mac') ? "${jdkFolder}/jdk-14.jdk" : "${jdkFolder}/jdk-14"
 
+
 if (osName().contains('mac')) {
     run {
         jvmArgs += '-XstartOnFirstThread'
@@ -100,7 +101,7 @@ task jlink(type: Exec, dependsOn: prepareInput) {
 
     // Overwrite previous bundled jre.
     if (file(runtimePath).exists()) {
-        delete(file(runtimePath))
+        delete(files(runtimePath))
     }
 
     commandLine = [
@@ -116,12 +117,6 @@ task jlink(type: Exec, dependsOn: prepareInput) {
             '--output', runtimePath
     ]
 
-    doLast {
-        // Final debloat for jpackage
-        delete(file("${runtimePath}/conf"))
-        delete(file("${runtimePath}/legal"))
-        delete fileTree("${runtimePath}/bin").matching { include "api*.dll" }
-    }
 }
 
 // creates application bundle (executable + runtime)
@@ -134,13 +129,15 @@ task appBundle(type: Exec, dependsOn: jlink) {
         System.out.println("Jpackage Path: " + jpackagePath)
         System.out.println("Jdk Path: " + jdkPath)
     }
+
     def mainJarFileName = "${project.name}-${project.version}.jar"
     def commands = [
             jpackagePath,
+            '--package-type', 'app-image',
             '--name', project.appName,
             '--vendor', "Argentum Online Libre",
             '--app-version', "${project.version}",
-            '--output', distributionPath,
+            '--dest', distributionPath,
             '--runtime-image', runtimePath,
             '--input', inputPath,
             '--main-class', project.mainClassName,
@@ -171,10 +168,6 @@ task appBundle(type: Exec, dependsOn: jlink) {
                 into("${distributionPath}${project.appName}/app")
             }
         }
-
-        // Debloat for Windows users.
-        delete fileTree("${distributionPath}/${project.appName}/bin").matching { include "*.dll" exclude "applauncher.dll" }
-        delete fileTree("${distributionPath}/${project.appName}/app").matching { include "api*.dll" }
 
         System.out.println("Application '${project.appName}' packaged.")
         System.out.println(" -> location: ${distributionPath}${project.appName}/")

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -21,14 +21,6 @@ static def getJDK() { Jvm.current().getJavaHome().path }
 
 mainClassName = "launcher.DesktopLauncher"
 
-// Determine where the JDK is going to be (Windows/Linux and Mac)
-def jdkFolder = "${projectDir}/build/jdk"
-def runtimePath = osName().contains('mac') ? "${buildDir}/jre/contents/plugins/Java.runtime/Contents/Home" : "${buildDir}/jre"
-def distributionPath = "${buildDir}/distributionRelease/"
-def jpackagePath = osName().contains('mac') ? "${jdkFolder}/jdk-14.jdk/Contents/Home/bin/jpackage" : "${jdkFolder}/jdk-14/bin/jpackage"
-def jdkPath = osName().contains('mac') ? "${jdkFolder}/jdk-14.jdk" : "${jdkFolder}/jdk-14"
-
-
 if (osName().contains('mac')) {
     run {
         jvmArgs += '-XstartOnFirstThread'
@@ -44,134 +36,18 @@ task dist(type: Jar) {
     }
 }
 
+tasks.distZip.doLast {
+
+	copy {
+		
+		// Ese .JAR que viene en el zip no me sirve.
+		from zipTree("${buildDir}/distributions/desktop-${project.version}.zip").matching { include "*.jar" exclude "desktop-${project.version}.jar" }
+		into "${buildDir}/libs"
+		
+	}
+
+}
+
 dist.dependsOn classes
 run.dependsOn classes
 
-// creates a replacement runtime via jlink command (much smaller than jpackage)
-task jlink(type: Exec, dependsOn: build) {
-
-    doFirst {
-        download {
-
-            if (osName().contains('windows')) {
-                src 'https://download.java.net/java/early_access/jpackage/1/openjdk-14-jpackage+1-49_windows-x64_bin.zip'
-            } else if (osName().contains('linux')) {
-                src 'https://download.java.net/java/early_access/jpackage/1/openjdk-14-jpackage+1-49_linux-x64_bin.tar.gz'
-            } else if (osName().contains('mac')) {
-                src 'https://download.java.net/java/early_access/jpackage/1/openjdk-14-jpackage+1-49_osx-x64_bin.tar.gz'
-            }
-
-            if (!file(jdkFolder).exists()) {
-                file(jdkFolder).mkdirs()
-            }
-            dest jdkFolder
-            overwrite false
-        }
-
-        if (!file(jdkPath).exists()) {
-            copy {
-
-                if (osName().contains('windows')) {
-                    from zipTree("${jdkFolder}/openjdk-14-jpackage+1-49_windows-x64_bin.zip")
-                } else if (osName().contains('linux')) {
-                    from tarTree("${jdkFolder}/openjdk-14-jpackage+1-49_linux-x64_bin.tar.gz")
-                } else if (osName().contains('mac')) {
-                    from tarTree("${jdkFolder}/openjdk-14-jpackage+1-49_osx-x64_bin.tar.gz")
-                }
-
-                into jdkFolder
-            }
-        }
-    }
-
-    // Overwrite previous packaged application.
-    if (file(distributionPath).exists()) {
-        delete(file(distributionPath))
-    }
-
-    // Overwrite previous bundled jre.
-    if (file(runtimePath).exists()) {
-        delete(files(runtimePath))
-    }
-
-    commandLine = [
-            getJDK().concat("/bin/jlink"),
-            '--module-path', getJDK().concat("/jmods"),
-            '--add-modules', 'java.base,java.desktop,jdk.unsupported,java.logging',
-            '--strip-debug',
-            '--no-header-files',
-            '--no-man-pages',
-            '--strip-native-commands',
-            '--vm=server',
-            '--compress=2',
-            '--output', runtimePath
-    ]
-	
-	doLast {
-        // Final debloat for jpackage
-        delete(file("${runtimePath}/conf"))
-        delete(file("${runtimePath}/legal"))
-        delete fileTree("${runtimePath}/bin").matching { include "api*.dll" }
-    }
-	
-}
-
-// creates application bundle (executable + runtime)
-task appBundle(type: Exec, dependsOn: jlink) {
-
-    doFirst {
-        System.out.println("Runtime Path: " + runtimePath)
-        System.out.println("Distribution Path: " + distributionPath)
-        System.out.println("Jpackage Path: " + jpackagePath)
-        System.out.println("Jdk Path: " + jdkPath)
-    }
-
-    def commands = [
-            jpackagePath,
-            '--package-type', 'app-image',
-            '--name', project.appName,
-            '--vendor', "Argentum Online Libre",
-            '--app-version', "${project.version}",
-            '--dest', distributionPath,
-            '--runtime-image', runtimePath,
-            '--input', "${buildDir}${File.separator}libs",
-            '--main-class', project.mainClassName,
-            '--main-jar', "desktop-${project.version}.jar",
-    ]
-
-    if (osName().contains('windows')) {
-        commands << "--icon"
-        commands << "${projectDir}/assets/data/icons/ao.ico"
-    } else if (osName().contains('linux')) {
-        commands << "--icon"
-        commands << "${projectDir}/assets/data/icons/ao.png"
-    } else if (osName().contains('mac')) {
-        commands << "--icon"
-        commands << "${projectDir}/assets/data/icons/ao.icns"
-        commands << "--java-options"
-        commands << "-XstartOnFirstThread"
-    }
-
-    commandLine = commands
-
-    doLast() {
-	
-        copy {
-            from("${projectDir}/Config.json")
-			from files("${projectDir}/assets")
-            if (osName().contains('mac')) {
-                into("${distributionPath}${project.appName}/Contents/Resources/")
-            } else {
-                into("${distributionPath}${project.appName}")
-            }
-        }
-		
-		// Debloat for Windows users.
-        delete fileTree("${distributionPath}/${project.appName}/bin").matching { include "*.dll" exclude "applauncher.dll" }
-        delete fileTree("${distributionPath}/${project.appName}/app").matching { include "api*.dll" }
-		delete file("${distributionPath}/${project.appName}/.jpackage.xml")
-
-        System.out.println("Application '${project.appName}' packaged.")
-        System.out.println(" -> location: ${distributionPath}${project.appName}/")
-    }
-}

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -169,6 +169,7 @@ task appBundle(type: Exec, dependsOn: jlink) {
 		// Debloat for Windows users.
         delete fileTree("${distributionPath}/${project.appName}/bin").matching { include "*.dll" exclude "applauncher.dll" }
         delete fileTree("${distributionPath}/${project.appName}/app").matching { include "api*.dll" }
+		delete file("${distributionPath}/${project.appName}/.jpackage.xml")
 
         System.out.println("Application '${project.appName}' packaged.")
         System.out.println(" -> location: ${distributionPath}${project.appName}/")

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -24,8 +24,7 @@ mainClassName = "launcher.DesktopLauncher"
 // Determine where the JDK is going to be (Windows/Linux and Mac)
 def jdkFolder = "${projectDir}/build/jdk"
 def runtimePath = osName().contains('mac') ? "${buildDir}/jre/contents/plugins/Java.runtime/Contents/Home" : "${buildDir}/jre"
-def distributionPath = "${buildDir}/distribution/"
-def inputPath = "${projectDir}/build/input/"
+def distributionPath = "${buildDir}/distributionRelease/"
 def jpackagePath = osName().contains('mac') ? "${jdkFolder}/jdk-14.jdk/Contents/Home/bin/jpackage" : "${jdkFolder}/jdk-14/bin/jpackage"
 def jdkPath = osName().contains('mac') ? "${jdkFolder}/jdk-14.jdk" : "${jdkFolder}/jdk-14"
 
@@ -49,7 +48,7 @@ dist.dependsOn classes
 run.dependsOn classes
 
 // creates a replacement runtime via jlink command (much smaller than jpackage)
-task jlink(type: Exec, dependsOn: dist) {
+task jlink(type: Exec, dependsOn: build) {
 
     doFirst {
         download {
@@ -86,8 +85,8 @@ task jlink(type: Exec, dependsOn: dist) {
     }
 
     // Overwrite previous packaged application.
-    if (file("${buildDir}/distribution/${project.appName}").exists()) {
-        delete(file("${buildDir}/distribution/${project.appName}"))
+    if (file(distributionPath).exists()) {
+        delete(file(distributionPath))
     }
 
     // Overwrite previous bundled jre.
@@ -107,7 +106,14 @@ task jlink(type: Exec, dependsOn: dist) {
             '--compress=2',
             '--output', runtimePath
     ]
-
+	
+	doLast {
+        // Final debloat for jpackage
+        delete(file("${runtimePath}/conf"))
+        delete(file("${runtimePath}/legal"))
+        delete fileTree("${runtimePath}/bin").matching { include "api*.dll" }
+    }
+	
 }
 
 // creates application bundle (executable + runtime)
@@ -116,7 +122,6 @@ task appBundle(type: Exec, dependsOn: jlink) {
     doFirst {
         System.out.println("Runtime Path: " + runtimePath)
         System.out.println("Distribution Path: " + distributionPath)
-        System.out.println("Input Path: " + inputPath)
         System.out.println("Jpackage Path: " + jpackagePath)
         System.out.println("Jdk Path: " + jdkPath)
     }
@@ -129,9 +134,9 @@ task appBundle(type: Exec, dependsOn: jlink) {
             '--app-version', "${project.version}",
             '--dest', distributionPath,
             '--runtime-image', runtimePath,
-            '--input', "${buildDir}/libs",
+            '--input', "${buildDir}${File.separator}libs",
             '--main-class', project.mainClassName,
-            '--main-jar', "${project.name}-${project.version}.jar"
+            '--main-jar', "desktop-${project.version}.jar",
     ]
 
     if (osName().contains('windows')) {
@@ -150,15 +155,20 @@ task appBundle(type: Exec, dependsOn: jlink) {
     commandLine = commands
 
     doLast() {
+	
         copy {
             from("${projectDir}/Config.json")
 			from files("${projectDir}/assets")
             if (osName().contains('mac')) {
-                into("${distributionPath}${project.appName}.app/Contents/Resources/")
+                into("${distributionPath}${project.appName}/Contents/Resources/")
             } else {
-                into("${distributionPath}${project.appName}/app")
+                into("${distributionPath}${project.appName}")
             }
         }
+		
+		// Debloat for Windows users.
+        delete fileTree("${distributionPath}/${project.appName}/bin").matching { include "*.dll" exclude "applauncher.dll" }
+        delete fileTree("${distributionPath}/${project.appName}/app").matching { include "api*.dll" }
 
         System.out.println("Application '${project.appName}' packaged.")
         System.out.println(" -> location: ${distributionPath}${project.appName}/")

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -48,17 +48,8 @@ task dist(type: Jar) {
 dist.dependsOn classes
 run.dependsOn classes
 
-task prepareInput(dependsOn: dist) {
-    copy {
-        from files(sourceSets.main.resources.srcDirs)
-        from("${buildDir}/libs/" + "${project.name}-${project.version}.jar")
-
-        into inputPath
-    }
-}
-
 // creates a replacement runtime via jlink command (much smaller than jpackage)
-task jlink(type: Exec, dependsOn: prepareInput) {
+task jlink(type: Exec, dependsOn: dist) {
 
     doFirst {
         download {
@@ -130,7 +121,6 @@ task appBundle(type: Exec, dependsOn: jlink) {
         System.out.println("Jdk Path: " + jdkPath)
     }
 
-    def mainJarFileName = "${project.name}-${project.version}.jar"
     def commands = [
             jpackagePath,
             '--package-type', 'app-image',
@@ -139,9 +129,9 @@ task appBundle(type: Exec, dependsOn: jlink) {
             '--app-version', "${project.version}",
             '--dest', distributionPath,
             '--runtime-image', runtimePath,
-            '--input', inputPath,
+            '--input', "${buildDir}/libs",
             '--main-class', project.mainClassName,
-            '--main-jar', mainJarFileName
+            '--main-jar', "${project.name}-${project.version}.jar"
     ]
 
     if (osName().contains('windows')) {
@@ -162,6 +152,7 @@ task appBundle(type: Exec, dependsOn: jlink) {
     doLast() {
         copy {
             from("${projectDir}/Config.json")
+			from files("${projectDir}/assets")
             if (osName().contains('mac')) {
                 into("${distributionPath}${project.appName}.app/Contents/Resources/")
             } else {

--- a/desktop/bundle.bat
+++ b/desktop/bundle.bat
@@ -1,0 +1,50 @@
+@echo off
+SETLOCAL
+
+set DIR=%~dp0
+set JPACKAGE_BINARYNAME="openjdk-14-jpackage+1-49_windows-x64_bin.zip"
+
+set RELEASE_DESTINATIONPATH="%DIR%build\releases"
+
+set PROJECT_NAME=AO-Java
+set PROJECT_VENDOR=AO-Libre
+set PROJECT_VERSION=0.1.12
+set PROJECT_JARSDIR="%DIR%build\libs"
+set PROJECT_ICON="%DIR%assets\data\icons\ao.ico"
+
+set PROJECT_JREDIR="%DIR%jre"
+
+REM We download the JPackage binary if wxists.
+IF /I NOT EXIST "%DIR%%JPACKAGE_BINARYNAME%" wget.exe "https://download.java.net/java/early_access/jpackage/1/%JPACKAGE_BINARYNAME%"
+
+REM We unZip the downloaded JPackage binary.
+IF NOT EXIST "%DIR%jdk-14" (
+	IF EXIST "C:\Program Files\WinRAR\WinRAR.exe" (
+		"C:\Program Files\WinRAR\WinRAR.exe" x "%DIR%%JPACKAGE_BINARYNAME%" %DIR%
+	) ELSE IF EXIST "C:\Program Files(x86)\WinRAR\WinRAR.exe" (
+		"C:\Program Files(x86)\WinRAR\WinRAR.exe" x "%DIR%%JPACKAGE_BINARYNAME%" %DIR%
+	)
+)
+
+REM Overwrite 'jre' dir if it alredy exists.
+rmdir /S /Q %PROJECT_JREDIR%
+
+REM Create an specific JRE for this proyect. Aprox. 30-40 MB.
+jlink --module-path C:\Java\jmods --add-modules java.base,java.desktop,jdk.unsupported,java.logging --strip-debug --no-header-files --no-man-pages --strip-native-commands --vm=server --compress=2 --output %PROJECT_JREDIR%
+
+REM Debloat even more the generated JRE.
+cd %PROJECT_JREDIR%
+rmdir /S /Q conf
+rmdir /S /Q legal
+cd bin
+del "api*.dll"
+cd %DIR%
+
+REM Overwrite previous generated release.
+rmdir /S /Q %RELEASE_DESTINATIONPATH%
+
+"jdk-14\bin\jpackage.exe" --package-type app-image --name %PROJECT_NAME% --vendor %PROJECT_VENDOR% --app-version %PROJECT_VERSION% --dest %RELEASE_DESTINATIONPATH% --runtime-image %PROJECT_JREDIR% --input %PROJECT_JARSDIR% --main-class launcher.DesktopLauncher --main-jar desktop-%PROJECT_VERSION%.jar --icon %PROJECT_ICON%
+
+REM Copy all resources in ${buildDir}/assets to the release destination path.
+xcopy  /E /I /Y /Q "%DIR%assets" %RELEASE_DESTINATIONPATH%\%PROJECT_NAME%
+copy "%DIR%Config.json" %RELEASE_DESTINATIONPATH%\%PROJECT_NAME%


### PR DESCRIPTION
Jpackage es utilizado para crear las releases.
Actualmente esta utilizando la versión 14 de jdk.
Esta implementación requiere de revisión, esta en fase beta, todavía no puede ser implementada.
**Causa de la falla (parte 1):** #129 
**Forma de reproducirlo:** gradlew.bat desktop:appBundle

Update:
@guidota Volvio el error ese del working dir....... :|