### PR TITLE
Posible solución a la versión de travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,4 @@ jdk:
   - openjdk12
 
 script:
-  - ./gradlew clean
   - ./gradlew compileJava

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http://services.gradle.org/distributions/gradle-5.6-all.zip
+distributionUrl=http://services.gradle.org/distributions/gradle-5.5.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http://services.gradle.org/distributions/gradle-5.5.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.5.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=http://services.gradle.org/distributions/gradle-5.6-all.zip


### PR DESCRIPTION
Travis dejo de compilar correctamente, volvemos atrás con la versión para testear que este funcionando. 
UPDATE: al parecer las fallas en la compilación de Travis se trata el ancho de banda asignado para la descarga del paquete o es posible que haya que reiniciar los archivos locales de la VM :man_shrugging: 
