### PR TITLE
[fix-gradle-url] Ads protocol secure for download gradle

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.2-all.zip


### PR DESCRIPTION
Travis arrojaba un error de compilación que no nos permitía testear los cambios. La solución fue agregar el protocolo seguro en la url para descargar gradle.