### PR TITLE
[gradle] [modifica] Actualizo gradle y mejora en manejo de versiones.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,13 +31,13 @@ allprojects {
         artemisVersion = '2.2.0'
         artemisContribVersion = '2.2.0'
         gdxAIVersion = '1.8.2'
-		tinyfdVersion = '3.2.3'
-		jupiterVersion = '5.5.2'
-		guavaVersion = '28.1-jre'
-		ini4jVersion = '0.5.4'
-		kotlinxCoroutinesVersion = '1.3.2'
-		kaifu2xVersion = '0.4.0'
-		reflectionsVersion = '0.9.11'
+	tinyfdVersion = '3.2.3'
+	jupiterVersion = '5.5.2'
+	guavaVersion = '28.1-jre'
+	ini4jVersion = '0.5.4'
+	kotlinxCoroutinesVersion = '1.3.2'
+	kaifu2xVersion = '0.4.0'
+	reflectionsVersion = '0.9.11'
     }
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ allprojects {
 }
 
 subprojects {
-    apply plugin: "java"
+    apply plugin: "java-library"
 
     sourceCompatibility = JavaVersion.VERSION_12
     targetCompatibility = JavaVersion.VERSION_12

--- a/build.gradle
+++ b/build.gradle
@@ -25,12 +25,12 @@ allprojects {
     version = '0.1.12'
 
     ext {
-        appName = 'ao-java'
-        gdxVersion = '1.9.11-SNAPSHOT'
-        kryonetVersion = '2.22.0-RC1'
-        artemisVersion = '2.2.0'
-        artemisContribVersion = '2.2.0'
-        gdxAIVersion = '1.8.2'
+    appName = 'ao-Java'
+    gdxVersion = '1.9.11-SNAPSHOT' //graphic library
+    kryonetVersion = '2.22.0-RC1' //protocol tcp-ip udp
+    artemisVersion = '2.2.0'  //ECS Artemis
+    artemisContribVersion = '2.2.0'
+    gdxAIVersion = '1.8.2' //artificial intelligence
 	tinyfdVersion = '3.2.3'
 	jupiterVersion = '5.5.2'
 	guavaVersion = '28.1-jre'

--- a/build.gradle
+++ b/build.gradle
@@ -26,12 +26,18 @@ allprojects {
 
     ext {
         appName = 'ao-java'
-        gdxVersion = '1.9.10'
+        gdxVersion = '1.9.11-SNAPSHOT'
         kryonetVersion = '2.22.0-RC1'
-        freetypeVersion = '1.9.9'
         artemisVersion = '2.2.0'
         artemisContribVersion = '2.2.0'
-        gdxAIVersion = '1.8.1'
+        gdxAIVersion = '1.8.2'
+		tinyfdVersion = '3.2.3'
+		jupiterVersion = '5.5.2'
+		guavaVersion = '28.1-jre'
+		ini4jVersion = '0.5.4'
+		kotlinxCoroutinesVersion = '1.3.2'
+		kaifu2xVersion = '0.4.0'
+		reflectionsVersion = '0.9.11'
     }
 
     repositories {

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -3,7 +3,6 @@ sourceSets.main.java.srcDirs = ["src/"]
 dependencies {
     api project(":shared")
 	api group: "com.badlogicgames.gdx", name: "gdx-freetype", version: "$gdxVersion"
-	compileOnly group: "com.badlogicgames.gdx", name: "gdx-backend-lwjgl3", version: "$gdxVersion"
     api("com.badlogicgames.gdx:gdx-tools:$gdxVersion") {
         exclude group: "com.badlogicgames.gdx", module: "gdx-backend-lwjgl"
     }

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -2,10 +2,10 @@ sourceSets.main.java.srcDirs = ["src/"]
 
 dependencies {
     compile project(":shared")
-    compile "com.badlogicgames.gdx:gdx-freetype:$freetypeVersion"
+    compile "com.badlogicgames.gdx:gdx-freetype:$gdxVersion"
     compile "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
     compile("com.badlogicgames.gdx:gdx-tools:$gdxVersion") {
-        exclude group: 'com.badlogicgames.gdx', module: 'gdx-backend-lwjgl'
+        exclude group: "com.badlogicgames.gdx", module: "gdx-backend-lwjgl"
     }
-    compile "org.reflections:reflections:0.9.11"
+    compile "org.reflections:reflections:$reflectionsVersion"
 }

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -1,11 +1,11 @@
 sourceSets.main.java.srcDirs = ["src/"]
 
 dependencies {
-    compile project(":shared")
-    compile "com.badlogicgames.gdx:gdx-freetype:$gdxVersion"
-    compile "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
-    compile("com.badlogicgames.gdx:gdx-tools:$gdxVersion") {
+    api project(":shared")
+	api group: "com.badlogicgames.gdx", name: "gdx-freetype", version: "$gdxVersion"
+	compileOnly group: "com.badlogicgames.gdx", name: "gdx-backend-lwjgl3", version: "$gdxVersion"
+    api("com.badlogicgames.gdx:gdx-tools:$gdxVersion") {
         exclude group: "com.badlogicgames.gdx", module: "gdx-backend-lwjgl"
     }
-    compile "org.reflections:reflections:$reflectionsVersion"
+	api group: "org.reflections", name: "reflections", version: "$reflectionsVersion"
 }

--- a/components/build.gradle
+++ b/components/build.gradle
@@ -2,6 +2,6 @@
 sourceSets.main.java.srcDirs = ["src/"]
 
 dependencies {
-    compile "com.badlogicgames.gdx:gdx:$gdxVersion"
-    compile "net.onedaybeard.artemis:artemis-odb:$artemisVersion"
+	api group: "com.badlogicgames.gdx", name: "gdx", version: "$gdxVersion"
+	api group: "net.onedaybeard.artemis", name: "artemis-odb", version: "$artemisVersion"
 }

--- a/design/build.gradle
+++ b/design/build.gradle
@@ -12,12 +12,12 @@ mainClassName = "launcher.DesignCenterLauncher"
 
 dependencies {
     compile project(":desktop")
-    compile "com.soywiz:kaifu2x:0.4.0"
-    compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2"
-    compile "org.lwjgl:lwjgl-tinyfd:3.2.0"
-    compile "org.lwjgl:lwjgl-tinyfd:3.2.0:natives-windows"
-    compile "org.lwjgl:lwjgl-tinyfd:3.2.0:natives-linux"
-    compile "org.lwjgl:lwjgl-tinyfd:3.2.0:natives-macos"
+    compile "com.soywiz:kaifu2x:$kaifu2xVersion"
+    compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion"
+    compile "org.lwjgl:lwjgl-tinyfd:$tinyfdVersion"
+    compile "org.lwjgl:lwjgl-tinyfd:$tinyfdVersion:natives-windows"
+    compile "org.lwjgl:lwjgl-tinyfd:$tinyfdVersion:natives-linux"
+    compile "org.lwjgl:lwjgl-tinyfd:$tinyfdVersion:natives-macos"
 }
 
 run.dependsOn classes

--- a/design/build.gradle
+++ b/design/build.gradle
@@ -11,13 +11,13 @@ sourceSets {
 mainClassName = "launcher.DesignCenterLauncher"
 
 dependencies {
-    compile project(":desktop")
-    compile "com.soywiz:kaifu2x:$kaifu2xVersion"
-    compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion"
-    compile "org.lwjgl:lwjgl-tinyfd:$tinyfdVersion"
-    compile "org.lwjgl:lwjgl-tinyfd:$tinyfdVersion:natives-windows"
-    compile "org.lwjgl:lwjgl-tinyfd:$tinyfdVersion:natives-linux"
-    compile "org.lwjgl:lwjgl-tinyfd:$tinyfdVersion:natives-macos"
+    implementation project(":desktop")
+	implementation group: "com.soywiz", name: "kaifu2x", version: "$kaifu2xVersion"
+	implementation group: "org.jetbrains.kotlinx", name: "kotlinx-coroutines-core", version: "$kotlinxCoroutinesVersion"
+	implementation group: "org.lwjgl", name: "lwjgl-tinyfd", version: "$tinyfdVersion"
+	implementation group: "org.lwjgl", name: "lwjgl-tinyfd", version: "$tinyfdVersion", classifier: "natives-windows"
+	implementation group: "org.lwjgl", name: "lwjgl-tinyfd", version: "$tinyfdVersion", classifier: "natives-linux"
+	implementation group: "org.lwjgl", name: "lwjgl-tinyfd", version: "$tinyfdVersion", classifier: "natives-macos"
 }
 
 run.dependsOn classes

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -11,9 +11,9 @@ sourceSets {
 }
 
 dependencies {
-    compile project(":client")
-    compile "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
-    compile "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-desktop"
+    implementation project(":client")
+	api group: "com.badlogicgames.gdx", name: "gdx-backend-lwjgl3", version: "$gdxVersion"
+	api group: "com.badlogicgames.gdx", name: "gdx-freetype-platform", version: "$gdxVersion", classifier: "natives-desktop"
 }
 
 static def osName() { System.getProperty('os.name').toLowerCase(Locale.ROOT) }

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -11,7 +11,7 @@ sourceSets {
 }
 
 dependencies {
-    implementation project(":client")
+    api project(":client")
 	api group: "com.badlogicgames.gdx", name: "gdx-backend-lwjgl3", version: "$gdxVersion"
 	api group: "com.badlogicgames.gdx", name: "gdx-freetype-platform", version: "$gdxVersion", classifier: "natives-desktop"
 }

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -13,7 +13,7 @@ sourceSets {
 dependencies {
     compile project(":client")
     compile "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
-    compile "com.badlogicgames.gdx:gdx-freetype-platform:$freetypeVersion:natives-desktop"
+    compile "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-desktop"
 }
 
 static def osName() { System.getProperty('os.name').toLowerCase(Locale.ROOT) }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -31,8 +31,8 @@ dependencies {
     implementation "com.badlogicgames.gdx:gdx-backend-headless:$gdxVersion"
     implementation "com.badlogicgames.gdx:gdx-ai:$gdxAIVersion"
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$jupiterVersion"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$jupiterVersion"
 }
 
 task dist(type: Jar) {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -27,12 +27,12 @@ test {
 
 dependencies {
     implementation project(":shared")
-    implementation "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
-    implementation "com.badlogicgames.gdx:gdx-backend-headless:$gdxVersion"
-    implementation "com.badlogicgames.gdx:gdx-ai:$gdxAIVersion"
+	runtimeOnly group: "com.badlogicgames.gdx", name: "gdx-backend-lwjgl3", version: "$gdxVersion"
+	implementation group: "com.badlogicgames.gdx", name: "gdx-backend-headless", version: "$gdxVersion"
+	implementation group: "com.badlogicgames.gdx", name: "gdx-ai", version: "$gdxAIVersion"
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:$jupiterVersion"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$jupiterVersion"
+	testImplementation group: "org.junit.jupiter", name: "junit-jupiter-api", version: "$jupiterVersion"
+	testRuntimeOnly group: "org.junit.jupiter", name: "junit-jupiter-engine", version: "$jupiterVersion"
 }
 
 task dist(type: Jar) {

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -5,13 +5,13 @@ plugins {
 
 dependencies {
     compile project(":components")
-    compile 'org.ini4j:ini4j:0.5.1'
+    compile "org.ini4j:ini4j:$ini4jVersion"
     compile "net.mostlyoriginal.artemis-odb:contrib-core:$artemisContribVersion"
     compile "net.mostlyoriginal.artemis-odb:contrib-jam:$artemisContribVersion"
     compile "net.mostlyoriginal.artemis-odb:contrib-eventbus:$artemisContribVersion"
     compile "net.mostlyoriginal.artemis-odb:contrib-network:$artemisContribVersion"
     compile "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
-    compile 'com.google.guava:guava:27.1-jre'
+    compile "com.google.guava:guava:$guavaVersion"
 }
 
 ext {

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -4,14 +4,14 @@ plugins {
 }
 
 dependencies {
-    compile project(":components")
-    compile "org.ini4j:ini4j:$ini4jVersion"
-    compile "net.mostlyoriginal.artemis-odb:contrib-core:$artemisContribVersion"
-    compile "net.mostlyoriginal.artemis-odb:contrib-jam:$artemisContribVersion"
-    compile "net.mostlyoriginal.artemis-odb:contrib-eventbus:$artemisContribVersion"
-    compile "net.mostlyoriginal.artemis-odb:contrib-network:$artemisContribVersion"
-    compile "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
-    compile "com.google.guava:guava:$guavaVersion"
+    api project(":components")
+	api group: "com.badlogicgames.gdx", name: "gdx-platform", version: "$gdxVersion", classifier: "natives-desktop"
+	api group: "net.mostlyoriginal.artemis-odb", name: "contrib-core", version: "$artemisContribVersion"
+	api group: "net.mostlyoriginal.artemis-odb", name: "contrib-jam", version: "$artemisContribVersion"
+	api group: "net.mostlyoriginal.artemis-odb", name: "contrib-eventbus", version: "$artemisContribVersion"
+	api group: "net.mostlyoriginal.artemis-odb", name: "contrib-network", version: "$artemisContribVersion"
+    api group: "com.google.guava", name: "guava", version: "$guavaVersion"
+	api group: "org.ini4j", name: "ini4j", version: "$ini4jVersion"
 }
 
 ext {


### PR DESCRIPTION
- Todas las versiones de las dependencias ahora se manejan desde el `build.gradle` de la carpeta principal.
- Actualizo la version de gradle 5.6.2 -> 5.6.4.
- Actualizo las versiones de las dependencias.
- Ahora las declaraciones de dependencias son mas amigables visualmente.
- Se sustituyó la palabra clave obsoleta desde Gradle 3.0 `compile` al declarar dependencias. (@guidota , si podes echarle un vistazo y decirme que onda...)

Testeado y funcional.