### PR TITLE
Renaming New York servername

### DIFF
--- a/desktop/Config.json
+++ b/desktop/Config.json
@@ -25,7 +25,7 @@
         "port": 7666
       },
       {
-        "name": "NewYork - Zhepyr",
+        "name": "NewYork - Zephyr",
         "hostname": "167.172.231.16",
         "port": 7666
       }


### PR DESCRIPTION
**Descripción:** renombre del servidor de New York (es Zephyr, no Zhepyr :) )