### PR TITLE
cant shoot that fast reemplaza a cant attack en AOInputProsessor

### DIFF
--- a/client/src/game/managers/AOInputProcessor.java
+++ b/client/src/game/managers/AOInputProcessor.java
@@ -82,7 +82,12 @@ public class AOInputProcessor extends Stage {
                         }
                         player.attack ( );
                     } else {
-                        gui.getConsole ( ).addWarning ( assetManager.getMessages ( Messages.CANT_ATTACK ) );
+                        if (toShoot) {
+                            gui.getConsole ( ).addWarning ( assetManager.getMessages ( Messages.CANT_SHOOT_THAT_FAST ) );
+                        } else {
+                            gui.getConsole ( ).addWarning ( assetManager.getMessages ( Messages.CANT_ATTACK) );
+                        }
+
                     }
                     Cursors.setCursor ( "hand" );
                     gui.getSpellView ( ).cleanCast ( );

--- a/shared/resources/lang/messages_en_US.properties
+++ b/shared/resources/lang/messages_en_US.properties
@@ -50,3 +50,4 @@ MAX_ROOM_LIMIT_CREATION_DESCRIPTION=The limit of rooms has been reached
 SPELLS_ADD=You've added the new spell {0} in Slot {1} of your spellbook.
 SPELLS_ALREDY_KNOWN=You already know the spell {0}.
 SPELLS_FULL=Your spellbook has reached its maximum capacity.
+CANT_SHOOT_THAT_FAST=You cant shoot that fast.

--- a/shared/resources/lang/messages_es_AR.properties
+++ b/shared/resources/lang/messages_es_AR.properties
@@ -49,3 +49,4 @@ MAX_ROOM_LIMIT_CREATION_DESCRIPTION=Se llegó al máximo de salas permitidas
 SPELLS_ADD=Agregaste el hechizo {0} en el slot {1} de tu libro de hechizos.
 SPELLS_ALREDY_KNOWN=Ya conocés el hechizo {0}.
 SPELLS_FULL=Tu libro de hechizos está lleno.
+CANT_SHOOT_THAT_FAST=No puedes disparar tan rapido. 

--- a/shared/resources/lang/messages_es_AR.properties
+++ b/shared/resources/lang/messages_es_AR.properties
@@ -49,4 +49,4 @@ MAX_ROOM_LIMIT_CREATION_DESCRIPTION=Se llegó al máximo de salas permitidas
 SPELLS_ADD=Agregaste el hechizo {0} en el slot {1} de tu libro de hechizos.
 SPELLS_ALREDY_KNOWN=Ya conocés el hechizo {0}.
 SPELLS_FULL=Tu libro de hechizos está lleno.
-CANT_SHOOT_THAT_FAST=No puedes disparar tan rapido. 
+CANT_SHOOT_THAT_FAST=No puedes disparar tan rápido. 

--- a/shared/resources/lang/messages_es_US.properties
+++ b/shared/resources/lang/messages_es_US.properties
@@ -49,4 +49,4 @@ MAX_ROOM_LIMIT_CREATION_DESCRIPTION=Se ha llegado al máximo de salas permitidas
 SPELLS_ADD=Has agregado el hechizo {0} en el slot {1} de tu libro de hechizos.
 SPELLS_ALREDY_KNOWN=Ya conoces el hechizo {0}.
 SPELLS_FULL=Tu libro de hechizos está lleno.
-CANT_SHOOT_THAT_FAST=No puedes disparar tan rapido.
+CANT_SHOOT_THAT_FAST=No puedes disparar tan rápido.

--- a/shared/resources/lang/messages_es_US.properties
+++ b/shared/resources/lang/messages_es_US.properties
@@ -49,3 +49,4 @@ MAX_ROOM_LIMIT_CREATION_DESCRIPTION=Se ha llegado al máximo de salas permitidas
 SPELLS_ADD=Has agregado el hechizo {0} en el slot {1} de tu libro de hechizos.
 SPELLS_ALREDY_KNOWN=Ya conoces el hechizo {0}.
 SPELLS_FULL=Tu libro de hechizos está lleno.
+CANT_SHOOT_THAT_FAST=No puedes disparar tan rapido.

--- a/shared/src/shared/util/Messages.java
+++ b/shared/src/shared/util/Messages.java
@@ -60,6 +60,7 @@ public enum Messages {
     // Ranged Combat
     CLICK_TO_SHOOT,
     DONT_HAVE_BOW_AND_ARROW,
+    CANT_SHOOT_THAT_FAST,
 
     // LOG IN MESSAGES
     FAILED_TO_CONNECT_TITLE,
@@ -72,5 +73,5 @@ public enum Messages {
     // SPELLS EXTENDED
     SPELLS_ADD,
     SPELLS_ALREDY_KNOWN,
-    SPELLS_FULL
+    SPELLS_FULL;
 }


### PR DESCRIPTION
Cambia el mensaje "no puedes atacar a ese objetivo" por "no puedes disparar tan rápido" cuando se usa repetidamente el ataque con arco en un intervalo muy corto de tiempo. 
cambios en los archivos de lenguaje según corresponde.