### PR TITLE
Encapsular connectionId dentro de Network 

### DIFF
--- a/server/src/server/systems/account/AccountSystem.java
+++ b/server/src/server/systems/account/AccountSystem.java
@@ -46,7 +46,7 @@ public class AccountSystem extends PassiveSystem {
             }
         }
 
-        serverSystem.sendTo(connectionID, new AccountCreationResponse(successful));
+        serverSystem.sendByConnectionId(connectionID, new AccountCreationResponse(successful));
         serverSystem.closeConnection(connectionID);
     }
 
@@ -55,11 +55,11 @@ public class AccountSystem extends PassiveSystem {
         Account requestedAccount = Account.load(email);
 
         if (requestedAccount == null) {
-            serverSystem.sendTo(connectionID, new AccountLoginResponse(Messages.NON_EXISTENT_ACCOUNT));
+            serverSystem.sendByConnectionId(connectionID, new AccountLoginResponse(Messages.NON_EXISTENT_ACCOUNT));
             serverSystem.closeConnection(connectionID);
             return;
         } else if (!AccountSystemUtilities.checkPassword(password, requestedAccount.getPassword())) {
-            serverSystem.sendTo(connectionID, new AccountLoginResponse(Messages.ACCOUNT_LOGIN_FAILED));
+            serverSystem.sendByConnectionId(connectionID, new AccountLoginResponse(Messages.ACCOUNT_LOGIN_FAILED));
             serverSystem.closeConnection(connectionID);
             return;
         }
@@ -116,7 +116,7 @@ public class AccountSystem extends PassiveSystem {
             }
         }
 
-        serverSystem.sendTo(connectionID, new AccountLoginResponse(email, characters, charactersData));
+        serverSystem.sendByConnectionId(connectionID, new AccountLoginResponse(email, characters, charactersData));
     }
 
     public Account getAccount(String email) {

--- a/server/src/server/systems/account/UserSystem.java
+++ b/server/src/server/systems/account/UserSystem.java
@@ -71,24 +71,24 @@ public class UserSystem extends PassiveSystem {
                 try {
                     Integer entityId = loadUser( userName ).get( 250, TimeUnit.MILLISECONDS );
                     if(entityId != -1) {
-                        serverSystem.sendTo( connectionId, UserLoginResponse.ok() );
+                        serverSystem.sendByConnectionId( connectionId, UserLoginResponse.ok() );
                         worldEntitiesSystem.login( connectionId, entityId );
                         onlineUsers.add(userName);
                     } else {
-                        serverSystem.sendTo( connectionId,
+                        serverSystem.sendByConnectionId( connectionId,
                                 UserLoginResponse.failed( "No se pudo leer el personaje " + userName + ". Por favor contactate con soporte." ) );
                     }
                 } catch (InterruptedException | ExecutionException | TimeoutException e) {
                     Log.info( "Failed to retrieve user from JSON file" );
                     e.printStackTrace();
-                    serverSystem.sendTo( connectionId,
+                    serverSystem.sendByConnectionId( connectionId,
                             UserLoginResponse.failed( "Hubo un problema al leer el personaje " + userName ) );
                 }
 
             } else {
                 // don't exist (should never happen)
                 // TODO remove from Account ?
-                serverSystem.sendTo( connectionId,
+                serverSystem.sendByConnectionId( connectionId,
                         UserLoginResponse.failed( "Este personaje " + userName + " no existe!" ) );
             }
         } else {
@@ -98,31 +98,31 @@ public class UserSystem extends PassiveSystem {
 
     //todo ver si el pj no esta en pelea para evitar desconeccion en ese caso
     public void userLogout(int connectionId){
-        serverSystem.sendTo( connectionId,new UserLogoutResponse());
+        serverSystem.sendByConnectionId( connectionId,new UserLogoutResponse());
     }
 
     public void create(int connectionId, String name, int heroId, String userAcc, int index) {
         UserSystemUtilities userSystemUtilities = new UserSystemUtilities();
 
         if (userSystemUtilities.userNameIsNumeric(name)) {
-            serverSystem.sendTo(connectionId,
+            serverSystem.sendByConnectionId(connectionId,
                     UserCreateResponse.failed(Messages.USERNAME_NOT_NUEMRIC));
 
         } else if (!userSystemUtilities.userNameIsNormalChar(name)) {
-            serverSystem.sendTo(connectionId,
+            serverSystem.sendByConnectionId(connectionId,
                     UserCreateResponse.failed(Messages.USERNAME_INVALID_CHAR));
 
         } else if (userSystemUtilities.userNameIsStartNumeric(name)) {
-            serverSystem.sendTo(connectionId,
+            serverSystem.sendByConnectionId(connectionId,
                     UserCreateResponse.failed(Messages.USERNAME_NOT_INIT_NUMBER));
 
         } else if (userSystemUtilities.userNameIsOfensive(name)) {
-            serverSystem.sendTo(connectionId,
+            serverSystem.sendByConnectionId(connectionId,
                     UserCreateResponse.failed(Messages.USERNAME_FORBIDDEN));
 
         } else if (userExists(name)) {
             // send user exists
-            serverSystem.sendTo(connectionId,
+            serverSystem.sendByConnectionId(connectionId,
                     UserCreateResponse.failed(Messages.USERNAME_ALREADY_EXIST));
         } else {
             // create and add to account
@@ -143,7 +143,7 @@ public class UserSystem extends PassiveSystem {
             }
             account.addCharacter(name, index);
             // send ok and login
-            serverSystem.sendTo(connectionId, UserCreateResponse.ok());
+            serverSystem.sendByConnectionId(connectionId, UserCreateResponse.ok());
             worldEntitiesSystem.login(connectionId, entityId);
         }
     }

--- a/server/src/server/systems/network/ServerRequestProcessor.java
+++ b/server/src/server/systems/network/ServerRequestProcessor.java
@@ -188,10 +188,11 @@ public class ServerRequestProcessor extends DefaultRequestProcessor {
         }
     }
 
-    // Todo: esta bien que este metodo reciba un playerId?
-    // Todo: Creo que es un bug y deberia recibir un connectionId como todos los demas.
     @Override
-    public void processRequest(@NotNull DropItem dropItem, int playerId) {
-        playerActionSystem.drop(playerId, dropItem.getCount(), dropItem.getPosition(), dropItem.getSlot());
+    public void processRequest(@NotNull DropItem dropItem, int connectionId) {
+        if (serverSystem.connectionHasPlayer(connectionId)) {
+            int playerId = serverSystem.getPlayerByConnection(connectionId);
+            playerActionSystem.drop(playerId, dropItem.getCount(), dropItem.getPosition(), dropItem.getSlot());
+        }
     }
 }

--- a/server/src/server/systems/network/ServerSystem.java
+++ b/server/src/server/systems/network/ServerSystem.java
@@ -57,11 +57,11 @@ public class ServerSystem extends MarshalSystem {
     }
 
     private void processJob(NetworkJob job) {
-        int connectionID = job.connectionID;
+        int connectionId = job.connectionID;
         Object object = job.receivedObject;
         try {
             if (object instanceof IRequest) {
-                ((IRequest) object).accept(requestProcessor, connectionID);
+                ((IRequest) object).accept(requestProcessor, connectionId);
             } else if (object instanceof INotification) {
                 ((INotification) object).accept(notificationProcessor);
             } else if (object instanceof FrameworkMessage) {
@@ -108,9 +108,14 @@ public class ServerSystem extends MarshalSystem {
      * @param connectionID
      * @param packet Object to send
      */
-    public void sendTo(int connectionID, Object packet) {
+    public void sendByConnectionId(int connectionID, Object packet) {
         ServerStrategy marshal = (ServerStrategy) getMarshal();
         marshal.sendTo(connectionID, packet);
+    }
+
+    public void sendByPlayerId(int playerId, Object packet) {
+        ServerStrategy marshal = (ServerStrategy) getMarshal();
+        marshal.sendTo(getConnectionByPlayer(playerId), packet);
     }
 
     public void registerUserConnection(int connectionID, int playerID) {

--- a/server/src/server/systems/world/WorldEntitiesSystem.java
+++ b/server/src/server/systems/world/WorldEntitiesSystem.java
@@ -37,7 +37,7 @@ import static com.artemis.E.E;
 public class WorldEntitiesSystem extends PassiveSystem {
 
     private MapSystem mapSystem;
-    private ServerSystem networkManager;
+    private ServerSystem serverSystem;
     private SpellSystem spellSystem;
     private ObjectSystem objectSystem;
     private EntityFactorySystem entityFactorySystem;
@@ -50,22 +50,22 @@ public class WorldEntitiesSystem extends PassiveSystem {
     }
 
     public void registerEntity(int connectionID, int playerID) {
-        networkManager.registerUserConnection(connectionID, playerID);
+        serverSystem.registerUserConnection(connectionID, playerID);
         registerEntity(playerID);
     }
 
     public void unregisterEntity(int entityId) {
         userSystem.save(entityId, () -> {
-            networkManager.unregisterUserConnection(entityId);
+            serverSystem.unregisterUserConnection(entityId);
             mapSystem.removeEntity(entityId);
             getWorld().delete(entityId);
         });
     }
 
     public void sendEntityUpdate(int user, Object update) {
-        if (networkManager.playerHasConnection(user)) {
+        if (serverSystem.playerHasConnection(user)) {
             Log.debug("Sending update: " + update.toString() + " to " + user);
-            networkManager.sendTo(networkManager.getConnectionByPlayer(user), update);
+            serverSystem.sendByConnectionId(serverSystem.getConnectionByPlayer(user), update);
         }
     }
 

--- a/server/src/server/systems/world/entity/item/ItemActionSystem.java
+++ b/server/src/server/systems/world/entity/item/ItemActionSystem.java
@@ -25,8 +25,7 @@ public class ItemActionSystem extends PassiveSystem {
     private MapSystem mapSystem;
     private WorldEntitiesSystem worldEntitiesSystem;
 
-    public void useItem(int connectionId, int action, int slot) {
-        int playerId = serverSystem.getPlayerByConnection(connectionId);
+    public void useItem(int playerId, int action, int slot) {
         E player = E.E(playerId);
         Bag.Item[] userItems = player.bagItems();
         if (slot < userItems.length) {
@@ -48,8 +47,7 @@ public class ItemActionSystem extends PassiveSystem {
         }
     }
 
-    public void grabItem(int connectionId) {
-        int playerId = serverSystem.getPlayerByConnection(connectionId);
+    public void grabItem(int playerId) {
         E player = E.E(playerId);
         WorldPos playerPos = player.getWorldPos();
         mapSystem.getNearEntities(playerId)
@@ -66,7 +64,7 @@ public class ItemActionSystem extends PassiveSystem {
                         Log.info("Adding item to index: " + index);
                         InventoryUpdate update = new InventoryUpdate();
                         update.add(index, player.bagItems()[index]);
-                        serverSystem.sendTo(connectionId, update);
+                        serverSystem.sendByPlayerId(playerId, update);
                         worldEntitiesSystem.unregisterEntity(objectEntityId);
                     } else {
                         Log.info("Could not put item in inventory (FULL?)");

--- a/server/src/server/systems/world/entity/movement/MovementSystem.java
+++ b/server/src/server/systems/world/entity/movement/MovementSystem.java
@@ -32,8 +32,7 @@ public class MovementSystem extends PassiveSystem {
     private MapSystem mapSystem;
     private EntityUpdateSystem entityUpdateSystem;
 
-    public void move(int connectionId, int movementIndex, int requestNumber) {
-        int playerId = serverSystem.getPlayerByConnection(connectionId);
+    public void move(int playerId, int movementIndex, int requestNumber) {
 
         // Obtiene la entidad a evaluar.
         E player = E.E(playerId);
@@ -84,7 +83,7 @@ public class MovementSystem extends PassiveSystem {
         }
 
         // notify user
-        serverSystem.sendTo(connectionId, new MovementResponse(requestNumber, nextPos));
+        serverSystem.sendByPlayerId(playerId, new MovementResponse(requestNumber, nextPos));
     }
 
 }

--- a/server/src/server/systems/world/entity/npc/NPCActionSystem.java
+++ b/server/src/server/systems/world/entity/npc/NPCActionSystem.java
@@ -19,9 +19,8 @@ public class NPCActionSystem extends PassiveSystem {
     private NPCSystem npcSystem;
 
     // TODO refactor, use npc types instead of names
-    public void interact(int connectionId, int targetEntity) {
+    public void interact(int playerId, int targetEntity) {
         NPC npc = npcSystem.getNpcs().get(targetEntity);
-        int playerId = serverSystem.getPlayerByConnection(connectionId);
         switch (npc.getName()) {
             case "Sacerdote":
                 if (E(playerId).healthMin() == 0) {

--- a/server/src/server/systems/world/entity/user/PlayerActionSystem.java
+++ b/server/src/server/systems/world/entity/user/PlayerActionSystem.java
@@ -43,8 +43,7 @@ public class PlayerActionSystem extends PassiveSystem {
     private CommandSystem commandSystem;
     private EntityUpdateSystem entityUpdateSystem;
 
-    public void drop(int connectionId, int count, WorldPos position, int slot) {
-        int playerId = serverSystem.getPlayerByConnection(connectionId);
+    public void drop(int playerId, int count, WorldPos position, int slot) {
         E entity = E.E(playerId);
 
         // Remove item from inventory
@@ -63,7 +62,7 @@ public class PlayerActionSystem extends PassiveSystem {
             bag.remove(slot);
         }
         update.add(slot, bag.items[slot]); // should remove item if count <= 0
-        serverSystem.sendTo(serverSystem.getConnectionByPlayer(playerId), update);
+        serverSystem.sendByConnectionId(serverSystem.getConnectionByPlayer(playerId), update);
 
         // Add new obj component.entity to world
         int object = world.create();
@@ -76,8 +75,7 @@ public class PlayerActionSystem extends PassiveSystem {
         worldEntitiesSystem.registerEntity(object);
     }
 
-    public void attack(int connectionId, long timestamp, WorldPos worldPos, AttackType type) {
-        int playerId = serverSystem.getPlayerByConnection(connectionId);
+    public void attack(int playerId, long timestamp, WorldPos worldPos, AttackType type) {
         E entity = E.E(playerId);
         if (!entity.hasAttackInterval()) {
             if (type.equals(AttackType.RANGED)) {
@@ -111,8 +109,7 @@ public class PlayerActionSystem extends PassiveSystem {
         }
     }
 
-    public void spell(int connectionId, Spell spell, WorldPos worldPos, long timestamp) {
-        int playerId = serverSystem.getPlayerByConnection(connectionId);
+    public void spell(int playerId, Spell spell, WorldPos worldPos, long timestamp) {
         E entity = E.E(playerId);
         if (!entity.hasAttackInterval()) {
             magicCombatSystem.spell(playerId, spell, worldPos, timestamp);

--- a/server/src/server/systems/world/entity/user/PlayerActionSystem.java
+++ b/server/src/server/systems/world/entity/user/PlayerActionSystem.java
@@ -62,7 +62,7 @@ public class PlayerActionSystem extends PassiveSystem {
             bag.remove(slot);
         }
         update.add(slot, bag.items[slot]); // should remove item if count <= 0
-        serverSystem.sendByConnectionId(serverSystem.getConnectionByPlayer(playerId), update);
+        serverSystem.sendByPlayerId(playerId, update);
 
         // Add new obj component.entity to world
         int object = world.create();

--- a/shared/src/shared/network/interaction/DropItem.java
+++ b/shared/src/shared/network/interaction/DropItem.java
@@ -37,7 +37,7 @@ public class DropItem implements IRequest {
     }
 
     @Override
-    public void accept(IRequestProcessor processor, int connectionId) {
-        processor.processRequest(this, connectionId);
+    public void accept(IRequestProcessor processor, int playerId) {
+        processor.processRequest(this, playerId);
     }
 }


### PR DESCRIPTION
#400
La clase `ServerRequestProcessor` es la encargada de procesar todos los `IRequests` que provienen del cliente.

En este PR, refactorizamos esta clase para que el `connectionId` del jugador no salga fuera de la misma. Así, evitamos tener dos formas redundantes de identificar a un jugador y reducimos posibles confusiones.