### PR TITLE
MapEditor Fixes

### DIFF
--- a/client/src/game/systems/camera/CameraSystem.java
+++ b/client/src/game/systems/camera/CameraSystem.java
@@ -6,12 +6,8 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.math.Interpolation;
 import com.badlogic.gdx.math.MathUtils;
-import com.badlogic.gdx.math.Rectangle;
-import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Scaling;
 import com.badlogic.gdx.utils.viewport.*;
-import game.PixelPerfectViewport;
-import shared.model.map.Tile;
 
 import static com.artemis.E.E;
 
@@ -35,8 +31,8 @@ public class CameraSystem extends BaseSystem {
     public CameraSystem(float minZoom, float maxZoom) {
         this(minZoom, maxZoom, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
     }
-
-    private CameraSystem(float minZoom, float maxZoom, float width, float height) {
+    // design hecho publico para poder dar el tamaño correcto
+    public CameraSystem(float minZoom, float maxZoom, float width, float height) {
         this.maxZoom = maxZoom;
         this.minZoom = minZoom;
         this.desiredZoom = maxZoom;
@@ -75,10 +71,11 @@ public class CameraSystem extends BaseSystem {
 
     public void zoom(float inout, float duration) {
         cameraZoomOrigin = camera.zoom;
-//        desiredZoom += inout * 0.025f;
-//        desiredZoom = MathUtils.clamp(desiredZoom, minZoom, maxZoom);
+        desiredZoom += inout * 0.025f;
+        desiredZoom = MathUtils.clamp(desiredZoom, minZoom, maxZoom);
 
-        desiredZoom = inout < 0 ? minZoom : maxZoom;
+        //design center es mejor gradual como esta arriba
+//        desiredZoom = inout < 0 ? minZoom : maxZoom;
         timeToCameraZoomTarget = cameraZoomDuration = duration;
     }
 

--- a/client/src/game/systems/map/MapManager.java
+++ b/client/src/game/systems/map/MapManager.java
@@ -51,6 +51,9 @@ public class MapManager extends BaseSystem {
                     // draw exit
                     doTileDraw(delta, x, y, 3);
                 }
+                if (drawExit && tile.getTrigger() > 0 ){
+                    doTileDraw(delta, x, y, 23652);
+                }
             }
         }
     }

--- a/design/src/design/screens/map/MapEditor.java
+++ b/design/src/design/screens/map/MapEditor.java
@@ -101,6 +101,10 @@ public class MapEditor extends DesignScreen {
                     x *= 70;
                     y *= 70;
                     world.getSystem(CameraSystem.class).camera.translate(x, y);
+                    Vector3 position = world.getSystem(CameraSystem.class).camera.position;
+                    position.x = MathUtils.clamp(position.x, 0, Tile.TILE_PIXEL_WIDTH * maxMapWidth);
+                    position.y = MathUtils.clamp(position.y, 0, Tile.TILE_PIXEL_HEIGHT * maxMapHeight);
+
                 }
                 return result;
             }

--- a/design/src/design/screens/map/gui/MapPalette.java
+++ b/design/src/design/screens/map/gui/MapPalette.java
@@ -26,7 +26,7 @@ public class MapPalette extends Window {
         setMovable(true);
 
         ButtonGroup layers = new ButtonGroup();
-        Button fst = new TextButton("1", SKIN, "file");
+        Button fst = new TextButton("Ground graphic", SKIN, "file");
         fst.addListener(new ClickListener() {
             @Override
             public void clicked(InputEvent event, float x, float y) {
@@ -35,7 +35,7 @@ public class MapPalette extends Window {
             }
         });
         add(fst).growX().row();
-        Button snd = new TextButton("2", SKIN, "file");
+        Button snd = new TextButton("Gound animation", SKIN, "file");
         snd.addListener(new ClickListener() {
             @Override
             public void clicked(InputEvent event, float x, float y) {
@@ -44,7 +44,7 @@ public class MapPalette extends Window {
             }
         });
         add(snd).growX().row();
-        Button third = new TextButton("3", SKIN, "file");
+        Button third = new TextButton("Middle", SKIN, "file");
         third.addListener(new ClickListener() {
             @Override
             public void clicked(InputEvent event, float x, float y) {
@@ -53,7 +53,7 @@ public class MapPalette extends Window {
             }
         });
         add(third).growX().row();
-        Button forth = new TextButton("4", SKIN, "file");
+        Button forth = new TextButton("Upper/roof", SKIN, "file");
         forth.addListener(new ClickListener() {
             @Override
             public void clicked(InputEvent event, float x, float y) {

--- a/design/src/design/screens/map/gui/MapProperties.java
+++ b/design/src/design/screens/map/gui/MapProperties.java
@@ -16,6 +16,7 @@ public class MapProperties extends Window {
     private Map current;
     private ClickListener mouseListener;
     private Table content;
+    private int[] neighbours;
 
     public MapProperties() {
         super("Map Properties", SKIN, "main");
@@ -32,7 +33,7 @@ public class MapProperties extends Window {
         current = map;
         content.add(StringEditor.simple("Map Name", map::setName, map::getName, () -> {
         })).row();
-        int[] neighbours = map.getNeighbours();
+        neighbours = map.getNeighbours();
         for (int i = 0; i < 4; i++) {
             int finalI = i;
             content.add(IntegerEditor.create(getNeighbourDisplay(i), id -> map.setNeighbour(finalI, id), () -> neighbours[finalI], () -> {
@@ -66,5 +67,8 @@ public class MapProperties extends Window {
 
     public boolean isOver() {
         return mouseListener.isOver();
+    }
+    public int[] getNeighbours(){
+        return neighbours;
     }
 }

--- a/design/src/design/screens/map/systems/DesignCameraFocusSystem.java
+++ b/design/src/design/screens/map/systems/DesignCameraFocusSystem.java
@@ -1,0 +1,32 @@
+package design.screens.map.systems;
+
+import com.artemis.Aspect;
+import com.artemis.E;
+import com.artemis.EBag;
+import com.artemis.annotations.Wire;
+import com.artemis.systems.IteratingSystem;
+import component.camera.AOCamera;
+import component.camera.Focused;
+import component.position.WorldPos;
+import game.utils.Pos2D;
+
+@Wire
+public class DesignCameraFocusSystem extends IteratingSystem {
+
+    public DesignCameraFocusSystem() {
+        super( Aspect.all( Focused.class, WorldPos.class));
+    }
+
+    @Override
+    protected void process(int player) {
+        EBag cameras = E.withComponent( AOCamera.class);
+        if (cameras.iterator().hasNext()) {
+            E playerEntity = E.E(player);
+            Pos2D pos = Pos2D.get(playerEntity).toScreen();
+            cameras.iterator().next()
+                    .worldPosOffsetsX(pos.x)
+                    .worldPosOffsetsY(pos.y);
+        }
+    }
+
+}

--- a/design/src/design/screens/map/systems/MapDesignRenderingSystem.java
+++ b/design/src/design/screens/map/systems/MapDesignRenderingSystem.java
@@ -19,7 +19,7 @@ import game.systems.render.BatchSystem;
 public class MapDesignRenderingSystem extends RenderingSystem {
 
     private final MapHelper helper;
-    ShapeRenderer sr = new ShapeRenderer();
+    ShapeRenderer shapeRenderer = new ShapeRenderer();
     private int current;
     private Map map;
     private MapManager mapManager;
@@ -31,13 +31,13 @@ public class MapDesignRenderingSystem extends RenderingSystem {
     public MapDesignRenderingSystem() {
         super(Aspect.all(Focused.class, WorldPos.class));
         helper = MapSystem.getHelper();
-        sr.setColor(Colors.TRANSPARENT_RED);
-        sr.setAutoShapeType(true);
+        shapeRenderer.setColor(Colors.TRANSPARENT_RED);
+        shapeRenderer.setAutoShapeType(true);
     }
 
-    public Map loadMap(int i) {
-        map = helper.getMap(i);
-        current = i;
+    public Map loadMap(int mapNumber) {
+        map = helper.getMap(mapNumber);
+        current = mapNumber;
         return map;
     }
 
@@ -45,7 +45,7 @@ public class MapDesignRenderingSystem extends RenderingSystem {
     protected void begin() {
         getCamera().update();
         batchRenderingSystem.getBatch().setProjectionMatrix(getCamera().combined);
-        sr.setProjectionMatrix(getCamera().combined);
+        shapeRenderer.setProjectionMatrix(getCamera().combined);
     }
 
     @Override
@@ -66,16 +66,16 @@ public class MapDesignRenderingSystem extends RenderingSystem {
                 batchRenderingSystem.getBatch().end();
             }
             if (showGrid) {
-                sr.begin();
+                shapeRenderer.begin();
                 float start = Tile.TILE_PIXEL_HEIGHT;
                 for (int i = 0; i < map.getHeight(); i++) {
                     // draw col
                     float x = (i + 1) * Tile.TILE_PIXEL_WIDTH;
-                    sr.line(x, start, x, map.getHeight() * Tile.TILE_PIXEL_HEIGHT);
+                    shapeRenderer.line(x, start, x, map.getHeight() * Tile.TILE_PIXEL_HEIGHT);
                     // draw row
-                    sr.line(start, x, map.getWidth() * Tile.TILE_PIXEL_WIDTH, x);
+                    shapeRenderer.line(start, x, map.getWidth() * Tile.TILE_PIXEL_WIDTH, x);
                 }
-                sr.end();
+                shapeRenderer.end();
             }
         }
         // draw tiles lines

--- a/design/src/design/screens/map/systems/MapDesignRenderingSystem.java
+++ b/design/src/design/screens/map/systems/MapDesignRenderingSystem.java
@@ -23,9 +23,7 @@ public class MapDesignRenderingSystem extends RenderingSystem {
     private int current;
     private Map map;
     private MapManager mapManager;
-    private boolean showExit;
-    private boolean showBlocks;
-    private boolean showGrid;
+    private boolean showExit, showBlocks, showGrid, showLayer1 = true, showLayer2= true, showLayer3=true, showLayer4= true;
     private BatchSystem batchRenderingSystem;
 
     public MapDesignRenderingSystem() {
@@ -61,6 +59,18 @@ public class MapDesignRenderingSystem extends RenderingSystem {
     protected void process(E e) {
         if (map != null) {
             for (int i = 0; i < 4; i++) {
+                if (!showLayer1 && i == 0){
+                    i++;
+                }
+                if (!showLayer2 && i == 1){
+                    i++;
+                }
+                if (!showLayer3 && i == 2){
+                    i++;
+                }
+                if (!showLayer4 && i == 3){
+                    break;
+                }
                 batchRenderingSystem.getBatch().begin();
                 mapManager.drawLayer(map, world.getDelta(), i, showExit, showBlocks);
                 batchRenderingSystem.getBatch().end();
@@ -95,5 +105,18 @@ public class MapDesignRenderingSystem extends RenderingSystem {
 
     public void toggleGrid() {
         showGrid = !showGrid;
+    }
+
+    public void toggleLayer1(){
+        showLayer1 = !showLayer1;
+    }
+    public void toggleLayer2(){
+        showLayer2 = !showLayer2;
+    }
+    public void toggleLayer3(){
+        showLayer3 = !showLayer3;
+    }
+    public void toggleLayer4(){
+        showLayer4 = !showLayer4;
     }
 }

--- a/shared/src/shared/util/MapHelper.java
+++ b/shared/src/shared/util/MapHelper.java
@@ -87,7 +87,8 @@ public class MapHelper {
     }
 
     public Map getMap(int i) {
-        if ( i > MAX_MAPS) {
+
+        if (i > MAX_MAPS) {
             return new Map();
         }else {
             return maps.getUnchecked( i );
@@ -157,19 +158,21 @@ public class MapHelper {
         }
     }
 
-//    @Deprecated
-//    private Map getMap_old(int i) {
-//        FileHandle mapPath = Gdx.files.internal(SharedResources.MAPS_FOLDER + "Alkon/Mapa" + i + ".map");
-//        FileHandle infPath = Gdx.files.internal(SharedResources.MAPS_FOLDER + "Alkon/Mapa" + i + ".inf");
-//        MapLoader loader = new MapLoader();
-//        try (DataInputStream map = new DataInputStream(mapPath.read());
-//             DataInputStream inf = new DataInputStream(infPath.read())) {
-//            return loader.load(map, inf);
-//        } catch (IOException | GdxRuntimeException e) {
-//            Log.error("Map I/O", "Failed to read map " + i, e);
-//            return new Map();
-//        }
-//    }
+/*
+    @Deprecated
+    private Map getMap_old(int i) {
+        FileHandle mapPath = Gdx.files.internal(SharedResources.MAPS_FOLDER + "Alkon/Mapa" + i + ".map");
+        FileHandle infPath = Gdx.files.internal(SharedResources.MAPS_FOLDER + "Alkon/Mapa" + i + ".inf");
+        MapLoader loader = new MapLoader();
+        try (DataInputStream map = new DataInputStream(mapPath.read());
+             DataInputStream inf = new DataInputStream(infPath.read())) {
+            return loader.load(map, inf);
+        } catch (IOException | GdxRuntimeException e) {
+            Log.error("Map I/O", "Failed to read map " + i, e);
+            return new Map();
+        }
+    }
+*/
 
     public boolean hasTileExit(Map map, WorldPos expectedPos) {
         Tile tile = map.getTile(expectedPos.x, expectedPos.y);


### PR DESCRIPTION
* Arreglado la pantalla
* Agregado un cuadro con el numero de mapa a cargar o guardar
* Se muestra posición X e Y del mouse
* Ahora guarda los mapas vecinos y el nombre del mapa
* Arreglo se pueden volver a poner animaciones en la capa 3
* Chequeo en el map helper para que no cargue un mapa mayor que el numero de mapas
* Agregado nombres a la paleta para saber a que corresponde cada layer.
* El botón ShowExits muestra también los Triggers 
* Botón help y tecla F1 una pequeña ventana de ayuda 
* 1, 2, 3, 4 desactiva y activa el renderizado de las capa correspondiente
* Volvemos a poder desplazarnos el mapa con el scroll del mouse(SHIFT scroll para horizontal)
* Manteniendo shift + click + movimiento del mouse podemos arrastrar el mapa
* Ctrl + scroll del mouse para zoom

**Por hacer**
- numero de trigger y posision a la que te manda el exit sean visible y editable
- mostrar npc
- poder agregar npc